### PR TITLE
Fixup CI not running on PR activity

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,9 @@
 name: "test"
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 jobs:
   test:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,9 @@
 name: "test"
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
 jobs:
   test:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
I missed adding a GH Actions trigger for PR activity in the test configuration. This should ensure that:

1. New pull requests are evaluated against `test/test`
2. Updates to pull request branches are evaluated against `test/test`
3. Pushes to `main` are evaluated against `test/test` when the PR is merged/rebased.