### PR TITLE
Add support for specifying duplicate HTTP response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Current
+
+* Added support for specifying duplicate HTTP response headers.
+
 ### `v0.1.0`
 
 * First published version.

--- a/docs/http.md
+++ b/docs/http.md
@@ -105,8 +105,9 @@ undefined.
     when a request matches.
     * **`body`**: (`String` | `Buffer` | `Function`) Response body.
     * **`headers`**: (`Object` | `Function`) Response headers.
-      * **`$key`**: (`String` | `Buffer` | `Function`) An individual response
-      header.
+      * **`$key`**: (`String` | `Buffer` | `Array` | `Function`) An individual
+        response header. If value is an array, will create a header for `$key`
+        for each value.
     * **`statusCode`**: (`Positive Int` | `Function`) Valid response status
       code.
     * **`headerDelay`**: (`Positive Int` | `Function`) Any delay in milliseconds
@@ -311,8 +312,8 @@ dep.mock({
 
 #### Duplicate Headers
 
-In the event that your application sends duplicate header values, they'll be
-matched as an array.
+In the event that your application sends duplicate headers, they'll be matched
+as an array.
 
 ```js
 dep.mock({
@@ -332,6 +333,19 @@ dep.mock({
   req: {
     headers: {
       'x-bloop': [/^blo+p$/, v => v.startsWith('t')]
+    }
+  }
+});
+```
+
+Similarly, you can respond with duplicate headers by specifying the values as an
+array:
+
+```js
+dep.mock({
+  res: {
+    headers: {
+      'x-bloop': ['bloop', () => Buffer.from('bloop', 'utf8')]
     }
   }
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,12 @@ type TCPFuncOptBoolable =
   | boolean
   | undefined;
 
-type HTTPResHeaders = { [key: string]: HTTPFuncOptBufferable } | undefined;
+type HTTPHeaderValue = OptBufferable | Array<HTTPFuncOptBufferable>;
+type HTTPFuncHeaderValue =
+  | ((req: IncomingMessage, reqBody: Buffer) => HTTPHeaderValue)
+  | HTTPHeaderValue;
+
+type HTTPResHeaders = { [key: string]: HTTPFuncHeaderValue } | undefined;
 
 type HTTPRes = {
   body?: HTTPFuncOptBufferable;

--- a/src/http/schema.js
+++ b/src/http/schema.js
@@ -47,11 +47,15 @@ export const funcOptBufferable = alias(
   'if defined must be string, buffer, or function returning same'
 );
 
-const isValidResHeaders = keyvals(always, funcOptBufferable);
+const resHeaderValue = branchWithFunction(
+  [optBufferable, isArray],
+  [always, arr(funcOptBufferable)],
+  'if defined must be string, buffer, or array'
+);
 
 const resHeaders = branchWithFunction(
   [isPlainObject, isUndefined],
-  [isValidResHeaders, always],
+  [keyvals(always, resHeaderValue), always],
   'if defined must be plain object'
 );
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -109,11 +109,25 @@ const toStatusCode = (value, ...args) => {
 const toHeaders = (value, ...args) => {
   value = safeInvoke(value, undefined, ...args);
 
+  let res = [];
+
   if (isPlainObject(value)) {
-    return mapObj(value, ([k, v]) => [k, toBuffer(v, ...args)]);
+    for (let [k, v] of Object.entries(value)) {
+      if (isFunction(v)) {
+        v = safeInvoke(v, undefined, ...args);
+      }
+
+      if (isArray(v)) {
+        for (const aV of v) {
+          res = [...res, k, toBuffer(aV, ...args)];
+        }
+      } else {
+        res = [...res, k, toBuffer(v, ...args)];
+      }
+    }
   }
 
-  return {};
+  return res;
 };
 
 const toBuffer = (value, ...args) => {
@@ -167,7 +181,6 @@ export const toTCPRes = (res, req) => {
   };
 };
 
-export const mapObj = (o, m) => Object.fromEntries(Object.entries(o).map(m));
 export const wait = (m) => new Promise((r) => setTimeout(() => r(), m));
 
 export const printMock = (mockType) => (obj) => {

--- a/test/lib-test.js
+++ b/test/lib-test.js
@@ -6,7 +6,6 @@ import {
   compare,
   toHTTPRes,
   toTCPRes,
-  mapObj,
   wait,
 } from '../src/lib.js';
 
@@ -215,7 +214,7 @@ describe('lib', function () {
         toHTTPRes(() => ({}), req, reqBody),
         {
           body: Buffer.from([]),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -233,7 +232,7 @@ describe('lib', function () {
         ),
         {
           body: Buffer.from([]),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -245,7 +244,7 @@ describe('lib', function () {
         toHTTPRes(() => ({ statusCode: 404 }), req, reqBody),
         {
           body: Buffer.from([]),
-          headers: {},
+          headers: [],
           statusCode: 404,
           bodyDelay: 0,
           headerDelay: 0,
@@ -257,7 +256,7 @@ describe('lib', function () {
         toHTTPRes((r, rB) => ({ body: `req: ${rB}` }), req, reqBody),
         {
           body: Buffer.from('req: bloop', 'utf8'),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -273,7 +272,7 @@ describe('lib', function () {
         ),
         {
           body: Buffer.from('req: bloop', 'utf8'),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -285,7 +284,7 @@ describe('lib', function () {
         toHTTPRes(() => ({ body: (r, rB) => `req: ${rB}` }), req, reqBody),
         {
           body: Buffer.from('req: bloop', 'utf8'),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -297,7 +296,7 @@ describe('lib', function () {
         toHTTPRes(() => new Date(), req, reqBody),
         {
           body: Buffer.from([]),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -309,7 +308,7 @@ describe('lib', function () {
     it('accepts an object', function () {
       assert.deepStrictEqual(toHTTPRes({ body: 'req: bloop' }, req, reqBody), {
         body: Buffer.from('req: bloop', 'utf8'),
-        headers: {},
+        headers: [],
         statusCode: 200,
         bodyDelay: 0,
         headerDelay: 0,
@@ -320,7 +319,7 @@ describe('lib', function () {
         toHTTPRes({ body: Buffer.from('req: bloop', 'utf8') }, req, reqBody),
         {
           body: Buffer.from('req: bloop', 'utf8'),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -332,7 +331,7 @@ describe('lib', function () {
         toHTTPRes({ body: (r, rB) => `req: ${rB}` }, req, reqBody),
         {
           body: Buffer.from('req: bloop', 'utf8'),
-          headers: {},
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -366,8 +365,8 @@ describe('lib', function () {
           reqBody
         ),
         {
-          body: Buffer.from([], 'utf8'),
-          headers: {},
+          body: Buffer.from([]),
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: 0,
@@ -389,8 +388,8 @@ describe('lib', function () {
           reqBody
         ),
         {
-          body: Buffer.from([], 'utf8'),
-          headers: {},
+          body: Buffer.from([]),
+          headers: [],
           statusCode: 200,
           bodyDelay: 0,
           headerDelay: -1,
@@ -417,17 +416,86 @@ describe('lib', function () {
           reqBody
         ),
         {
-          body: Buffer.from([], 'utf8'),
-          headers: {
-            'x-bloop': Buffer.from([]),
-            'x-bloop-2': Buffer.from('bloop!', 'utf8'),
-            'x-string': Buffer.from('string', 'utf8'),
-            'x-buffer': Buffer.from('buffer', 'utf8'),
-          },
+          body: Buffer.from([]),
+          headers: [
+            'x-bloop',
+            Buffer.from([]),
+            'x-bloop-2',
+            Buffer.from('bloop!', 'utf8'),
+            'x-string',
+            Buffer.from('string', 'utf8'),
+            'x-buffer',
+            Buffer.from('buffer', 'utf8'),
+          ],
           statusCode: 200,
           bodyDelay: 1,
           headerDelay: 30,
           destroySocket: true,
+        }
+      );
+
+      assert.deepStrictEqual(
+        toHTTPRes({
+          headers: {
+            'x-bloop': [undefined, 'bloop', Buffer.from('bloop', 'utf8')],
+          },
+        }),
+        {
+          body: Buffer.from([]),
+          bodyDelay: 0,
+          destroySocket: false,
+          headerDelay: 0,
+          headers: [
+            'x-bloop',
+            Buffer.from([]),
+            'x-bloop',
+            Buffer.from('bloop', 'utf8'),
+            'x-bloop',
+            Buffer.from('bloop', 'utf8'),
+          ],
+          statusCode: 200,
+        }
+      );
+
+      assert.deepStrictEqual(
+        toHTTPRes({
+          headers: {
+            'x-bloop': () => [undefined, 'bloop'],
+          },
+        }),
+        {
+          body: Buffer.from([]),
+          bodyDelay: 0,
+          destroySocket: false,
+          headerDelay: 0,
+          headers: [
+            'x-bloop',
+            Buffer.from([]),
+            'x-bloop',
+            Buffer.from('bloop', 'utf8'),
+          ],
+          statusCode: 200,
+        }
+      );
+
+      assert.deepStrictEqual(
+        toHTTPRes({
+          headers: {
+            'x-bloop': [() => undefined, () => 'bloop'],
+          },
+        }),
+        {
+          body: Buffer.from([]),
+          bodyDelay: 0,
+          destroySocket: false,
+          headerDelay: 0,
+          headers: [
+            'x-bloop',
+            Buffer.from([]),
+            'x-bloop',
+            Buffer.from('bloop', 'utf8'),
+          ],
+          statusCode: 200,
         }
       );
     });
@@ -614,19 +682,6 @@ describe('lib', function () {
           destroySocket: false,
         }
       );
-    });
-  });
-
-  describe('#mapObj', function () {
-    it('maps keys and values of an object', function () {
-      const value = { bloop: 1, bleep: 2 };
-
-      assert.deepStrictEqual(
-        mapObj(value, ([k, v]) => [k.toUpperCase(), v + 1]),
-        { BLOOP: 2, BLEEP: 3 }
-      );
-
-      assert.deepStrictEqual(value, { bloop: 1, bleep: 2 });
     });
   });
 

--- a/test/ts/types.ts
+++ b/test/ts/types.ts
@@ -110,7 +110,11 @@ httpDep.mock({
 httpDep.mock({
   res: {
     body: Buffer.from('body', 'utf8'),
-    headers: { 'x-bloop': Buffer.from('true', 'utf8') },
+    headers: {
+      'x-bloop': Buffer.from('true', 'utf8'),
+      'x-bleep': ['1', Buffer.from('2', 'utf8'), () => '3', undefined],
+      'x-bleep-2': () => ['1', Buffer.from('2', 'utf8'), () => '3', undefined],
+    },
   },
 });
 


### PR DESCRIPTION
Bit of a conspicuous omission in the `v0.1.0` release, this does as the title says. 

Duplicate HTTP headers are a bit of an oddity, but who is `wirepig` to tell folks how standard their HTTP messages ought to be?